### PR TITLE
Add healthcheck configuration for Celery service in Docker Compose

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -202,6 +202,12 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "celery", "-A", "personal_assistant.workers.celery_app", "inspect", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
     networks:
       - personal_assistant_prod_network
@@ -351,6 +357,12 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "celery", "-A", "personal_assistant.workers.celery_app", "inspect", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
     networks:
       - personal_assistant_prod_network


### PR DESCRIPTION
- Introduced healthcheck settings for the Celery service in `docker-compose.prod.yml`, specifying a command to inspect the service's health.
- Configured healthcheck parameters including interval, timeout, retries, and start period to enhance service reliability.

Status: Improved service monitoring and reliability for the Celery component in the production environment.