### PR TITLE
Update healthcheck command for Celery service in Docker Compose

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -203,7 +203,13 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "celery", "-A", "personal_assistant.workers.celery_app", "inspect", "ping"]
+      test:
+        [
+          "CMD",
+          "curl",
+          "-f",
+          "http://personal_assistant_api_prod:8000/health/overall",
+        ]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -358,7 +364,13 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "celery", "-A", "personal_assistant.workers.celery_app", "inspect", "ping"]
+      test:
+        [
+          "CMD",
+          "curl",
+          "-f",
+          "http://personal_assistant_api_prod:8000/health/overall",
+        ]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
- Replaced the healthcheck command for the Celery service in `docker-compose.prod.yml` to use a curl command that checks the overall health of the personal assistant API instead of the previous Celery inspect command.
- Maintained existing healthcheck parameters including interval, timeout, and retries to ensure service reliability.

Status: Enhanced service monitoring by aligning healthcheck with the API's health endpoint.