### PR TITLE
Remove PrototypePage from routing and exports

### DIFF
--- a/src/apps/frontend/src/App.tsx
+++ b/src/apps/frontend/src/App.tsx
@@ -28,7 +28,6 @@ import {
   SMSAnalyticsPage,
   AdminAnalyticsPage,
 } from '@/pages/dashboard';
-import PrototypePage from '@/pages/dashboard/PrototypePage';
 import PhoneManagementPage from '@/pages/dashboard/PhoneManagementPage';
 import { OAuthSettingsPage } from '@/components/oauth-settings';
 import ProtectedRoute from '@/components/auth/ProtectedRoute';
@@ -69,15 +68,6 @@ function App() {
             element={
               <ProtectedRoute requireAuth={false}>
                 <WaitListLandingPage />
-              </ProtectedRoute>
-            }
-          />
-
-          <Route
-            path="/prototype"
-            element={
-              <ProtectedRoute requireAuth={false}>
-                <PrototypePage />
               </ProtectedRoute>
             }
           />

--- a/src/apps/frontend/src/pages/dashboard/index.ts
+++ b/src/apps/frontend/src/pages/dashboard/index.ts
@@ -11,4 +11,3 @@ export { default as AITasksPage } from './AITasksPage';
 export { default as OAuthIntegrationsPage } from '../../components/oauth/OAuthIntegrationsPage';
 export { default as SMSAnalyticsPage } from './SMSAnalyticsPage';
 export { default as AdminAnalyticsPage } from './AdminAnalyticsPage';
-export { default as PrototypePage } from './PrototypePage';


### PR DESCRIPTION
- Deleted the `PrototypePage` route from `App.tsx` to streamline navigation.
- Removed the export of `PrototypePage` from `index.ts` in the dashboard directory to clean up unused components.

Status: Improved application structure by eliminating unused routes and exports, enhancing maintainability.